### PR TITLE
Feature/add delete function

### DIFF
--- a/LivingDesign.xcodeproj/project.pbxproj
+++ b/LivingDesign.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		439256AA2354A57300387FD3 /* Footer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439256A92354A57300387FD3 /* Footer.swift */; };
 		43963391237A63B800B26BDF /* Setting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43963390237A63B800B26BDF /* Setting.swift */; };
 		43A1C8BA236518A1007E5BC2 /* RealmUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A1C8B9236518A0007E5BC2 /* RealmUtility.swift */; };
+		43A3B9E4238C068000EBEBC0 /* UILabelWithID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A3B9E3238C068000EBEBC0 /* UILabelWithID.swift */; };
 		43A3CED3235EE0650009E965 /* washing-machine.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 43A3CEC5235EE0650009E965 /* washing-machine.pdf */; };
 		43A3CEDF235EF6110009E965 /* electric-kettle.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 43A3CEDD235EF6110009E965 /* electric-kettle.pdf */; };
 		43A3CEE0235EF6110009E965 /* copier.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 43A3CEDE235EF6110009E965 /* copier.pdf */; };
@@ -111,6 +112,7 @@
 		439256A92354A57300387FD3 /* Footer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Footer.swift; sourceTree = "<group>"; };
 		43963390237A63B800B26BDF /* Setting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Setting.swift; sourceTree = "<group>"; };
 		43A1C8B9236518A0007E5BC2 /* RealmUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmUtility.swift; sourceTree = "<group>"; };
+		43A3B9E3238C068000EBEBC0 /* UILabelWithID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UILabelWithID.swift; sourceTree = "<group>"; };
 		43A3CEC5235EE0650009E965 /* washing-machine.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "washing-machine.pdf"; sourceTree = "<group>"; };
 		43A3CEDD235EF6110009E965 /* electric-kettle.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "electric-kettle.pdf"; sourceTree = "<group>"; };
 		43A3CEDE235EF6110009E965 /* copier.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = copier.pdf; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 				4390DD15235E8CBF009E3C6F /* RootViewController.swift */,
 				4390DD19235E8F7C009E3C6F /* RootScreen.storyboard */,
 				43C37065236D6BBD0033BDCD /* test.storyboard */,
+				43A3B9E3238C068000EBEBC0 /* UILabelWithID.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -604,6 +607,7 @@
 				43CB4957236D052900FB2C6B /* HistoryTableViewCell.swift in Sources */,
 				43A1C8BA236518A1007E5BC2 /* RealmUtility.swift in Sources */,
 				4390DD16235E8CBF009E3C6F /* RootViewController.swift in Sources */,
+				43A3B9E4238C068000EBEBC0 /* UILabelWithID.swift in Sources */,
 				43963391237A63B800B26BDF /* Setting.swift in Sources */,
 				43F8B941235E885D000E084E /* Home.swift in Sources */,
 				436874752361E941001109AF /* DataStructure.swift in Sources */,

--- a/LivingDesign.xcodeproj/project.pbxproj
+++ b/LivingDesign.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		43963391237A63B800B26BDF /* Setting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43963390237A63B800B26BDF /* Setting.swift */; };
 		43A1C8BA236518A1007E5BC2 /* RealmUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A1C8B9236518A0007E5BC2 /* RealmUtility.swift */; };
 		43A3B9E4238C068000EBEBC0 /* UILabelWithID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A3B9E3238C068000EBEBC0 /* UILabelWithID.swift */; };
+		43A3B9E62391F97A00EBEBC0 /* ResetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A3B9E52391F97A00EBEBC0 /* ResetController.swift */; };
 		43A3CED3235EE0650009E965 /* washing-machine.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 43A3CEC5235EE0650009E965 /* washing-machine.pdf */; };
 		43A3CEDF235EF6110009E965 /* electric-kettle.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 43A3CEDD235EF6110009E965 /* electric-kettle.pdf */; };
 		43A3CEE0235EF6110009E965 /* copier.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 43A3CEDE235EF6110009E965 /* copier.pdf */; };
@@ -113,6 +114,7 @@
 		43963390237A63B800B26BDF /* Setting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Setting.swift; sourceTree = "<group>"; };
 		43A1C8B9236518A0007E5BC2 /* RealmUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmUtility.swift; sourceTree = "<group>"; };
 		43A3B9E3238C068000EBEBC0 /* UILabelWithID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UILabelWithID.swift; sourceTree = "<group>"; };
+		43A3B9E52391F97A00EBEBC0 /* ResetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetController.swift; sourceTree = "<group>"; };
 		43A3CEC5235EE0650009E965 /* washing-machine.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "washing-machine.pdf"; sourceTree = "<group>"; };
 		43A3CEDD235EF6110009E965 /* electric-kettle.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "electric-kettle.pdf"; sourceTree = "<group>"; };
 		43A3CEDE235EF6110009E965 /* copier.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = copier.pdf; sourceTree = "<group>"; };
@@ -276,6 +278,7 @@
 				4390DD19235E8F7C009E3C6F /* RootScreen.storyboard */,
 				43C37065236D6BBD0033BDCD /* test.storyboard */,
 				43A3B9E3238C068000EBEBC0 /* UILabelWithID.swift */,
+				43A3B9E52391F97A00EBEBC0 /* ResetController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -615,6 +618,7 @@
 				9F77ACCB235DD44000C8E7C0 /* Detail.swift in Sources */,
 				43C07A6C2369CE2500675363 /* Delete.swift in Sources */,
 				9F24B7EA235F056500035BFD /* NewProduct.swift in Sources */,
+				43A3B9E62391F97A00EBEBC0 /* ResetController.swift in Sources */,
 				435C5D01236A770E007ABCFC /* History.swift in Sources */,
 				439256AA2354A57300387FD3 /* Footer.swift in Sources */,
 				43C07A6E236A593F00675363 /* DeleteCollectionViewCell.swift in Sources */,

--- a/LivingDesign/AppDelegate.swift
+++ b/LivingDesign/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let config = Realm.Configuration(
             // データ構造変更するたびに更新する必要あり。前よりも大きな値にする
-            schemaVersion: 8,
+            schemaVersion: 9,
             
             //スキーマのバージョンが上記のものよりも低いものを開こうとした場合、自動的に呼び出されるブロックを設定する
             migrationBlock: { migration, oldSchemaVersion in
@@ -44,6 +44,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // jsonのデータにリセットしたい場合に使用
         // そうでない場合は、下の行をコメントする
         loadTestData()
+        
+        // DeleteCandidateが存在するなら、削除しちゃう
+        let deleteCandidateItemInRealm = realm.objects(DeleteCandidateItem.self)
+        
+        if(deleteCandidateItemInRealm.first != nil){
+            for dci in deleteCandidateItemInRealm{
+                try! realm.write {
+                    realm.delete(dci)
+                }
+            }
+            print("deleteCandidateItemを削除")
+        } else{
+            print("deleteCandidateItemは空")
+        }
         
         return true
     }

--- a/LivingDesign/AppDelegate.swift
+++ b/LivingDesign/AppDelegate.swift
@@ -13,12 +13,13 @@ import RealmSwift
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
+    private let resetController: ResetController = ResetController()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
         let config = Realm.Configuration(
             // データ構造変更するたびに更新する必要あり。前よりも大きな値にする
-            schemaVersion: 9,
+            schemaVersion: 11,
             
             //スキーマのバージョンが上記のものよりも低いものを開こうとした場合、自動的に呼び出されるブロックを設定する
             migrationBlock: { migration, oldSchemaVersion in
@@ -46,18 +47,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         loadTestData()
         
         // DeleteCandidateが存在するなら、削除しちゃう
-        let deleteCandidateItemInRealm = realm.objects(DeleteCandidateItem.self)
-        
-        if(deleteCandidateItemInRealm.first != nil){
-            for dci in deleteCandidateItemInRealm{
-                try! realm.write {
-                    realm.delete(dci)
-                }
-            }
-            print("deleteCandidateItemを削除")
-        } else{
-            print("deleteCandidateItemは空")
-        }
+        self.resetController.reset()
         
         return true
     }

--- a/LivingDesign/AppDelegate.swift
+++ b/LivingDesign/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let config = Realm.Configuration(
             // データ構造変更するたびに更新する必要あり。前よりも大きな値にする
-            schemaVersion: 11,
+            schemaVersion: 12,
             
             //スキーマのバージョンが上記のものよりも低いものを開こうとした場合、自動的に呼び出されるブロックを設定する
             migrationBlock: { migration, oldSchemaVersion in
@@ -92,6 +92,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         do {
             let itemInRealm = realm.objects(Item.self)
+            let allItemInRealm = realm.objects(AllItem.self)
             let path = Bundle.main.path(forResource: "testItemData", ofType:"json")
             let data = getFileData(path!)
             let testItemData = try! JSONDecoder().decode([Item].self, from: data!) as! [Item]
@@ -106,22 +107,37 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             } else{
                 print("itemは空")
             }
+            
+            if(allItemInRealm != nil){
+                for aiir in allItemInRealm{
+                    try! realm.write {
+                        realm.delete(aiir)
+                    }
+                }
+                print("allItemを削除")
+            } else{
+                print("allItemは空")
+            }
                 
             for tid in testItemData{
                 let item = Item()
-                item.name = tid.name
-                item.genre = tid.genre
-                item.modelNumber = tid.modelNumber
-                item.price = tid.price
-                item.purchaseDate = tid.purchaseDate
-                item.warrantyPeriod = tid.warrantyPeriod
-                item.reason = tid.reason
-                item.confort = tid.confort
-                item.otherTargets = tid.otherTargets
-                item.memo = tid.memo
-                item.photo = tid.photo
+                let allItem = AllItem()
+                allItem.setId(id: item.getId())
+                (allItem.name, item.name) = (tid.name, tid.name)
+                (allItem.genre, item.genre) = (tid.genre, tid.genre)
+                (allItem.modelNumber, item.modelNumber) = (tid.modelNumber, tid.modelNumber)
+                (allItem.price, item.price) = (tid.price, tid.price)
+                (allItem.purchaseDate, item.purchaseDate) = (tid.purchaseDate, tid.purchaseDate)
+                (allItem.warrantyPeriod, item.warrantyPeriod) = (tid.warrantyPeriod, tid.warrantyPeriod)
+                (allItem.reason, item.reason) = (tid.reason, tid.reason)
+                (allItem.confort, item.confort) = (tid.confort, tid.confort)
+                (allItem.otherTargets, item.otherTargets) = (tid.otherTargets, tid.otherTargets)
+                (allItem.memo, item.memo) = (tid.memo, tid.memo)
+                (allItem.photo, item.photo) = (tid.photo, tid.photo)
+                
                 try! realm.write{
                     realm.add(item)
+                    realm.add(allItem)
                 }
             }
             print("itemを追加")

--- a/LivingDesign/Data/DataStructure.swift
+++ b/LivingDesign/Data/DataStructure.swift
@@ -8,6 +8,10 @@
 
 import RealmSwift
 
+class DeleteCandidateItem: Object{
+    @objc dynamic var id: String = ""
+}
+
 class ShareInNavigation: Object{
     @objc dynamic var data: String = ""
 }

--- a/LivingDesign/Data/DataStructure.swift
+++ b/LivingDesign/Data/DataStructure.swift
@@ -28,6 +28,29 @@ class Item: Object, Decodable{
     @objc dynamic var price: Int = 0
     @objc dynamic var purchaseDate: String = ""  // YYYY/MM/DD形式 0埋めする
     @objc dynamic var warrantyPeriod: String = "" // YYYY/MM/DD形式 0埋めする
+    @objc dynamic var reason: String = ""
+    @objc dynamic var confort: Int = 3
+    @objc dynamic var otherTargets: String = ""
+    @objc dynamic var memo: String = ""
+    @objc dynamic var photo: String = ""
+    
+    @objc override static func primaryKey() -> String? {
+        return "id"
+    }
+    
+    @objc public func getId() -> String {
+        return self.id
+    }
+}
+
+class AllItem: Object, Decodable{
+    @objc private dynamic var id: String = ""
+    @objc dynamic var name: String = ""
+    @objc dynamic var genre: String = ""
+    @objc dynamic var modelNumber: String = ""
+    @objc dynamic var price: Int = 0
+    @objc dynamic var purchaseDate: String = ""  // YYYY/MM/DD形式 0埋めする
+    @objc dynamic var warrantyPeriod: String = "" // YYYY/MM/DD形式 0埋めする
     @objc private dynamic var disposalDate: String = "" // YYYY/MM/DD形式 0埋めする
     @objc dynamic var reason: String = ""
     @objc dynamic var confort: Int = 3
@@ -38,6 +61,10 @@ class Item: Object, Decodable{
     
     @objc override static func primaryKey() -> String? {
         return "id"
+    }
+    
+    @objc public func setId(id: String) -> Void {
+        self.id = id
     }
     
     @objc public func getId() -> String {

--- a/LivingDesign/Data/testItemData.json
+++ b/LivingDesign/Data/testItemData.json
@@ -7,12 +7,10 @@
         "price": 20000,
         "purchaseDate": "2019/11/10",
         "warrantyPeriod": "2021/11/10",
-        "disposalDate": "2019/12/10",
         "reason": "洗いやすい",
         "confort": 4,
         "otherTargets": "特になし",
         "memo": "めっちゃ綺麗になる",
-        "isUse": true,
         "photo": "washing-machine"
     },
     {
@@ -23,12 +21,10 @@
         "price": 10000,
         "purchaseDate": "2019/08/10",
         "warrantyPeriod": "2021/08/10",
-        "disposalDate": "2019/10/10",
         "reason": "4K",
         "confort": 5,
         "otherTargets": "ブラビア",
         "memo": "画質きれい",
-        "isUse": true,
         "photo": "tv"
     },
     {
@@ -39,12 +35,10 @@
         "price": 10000,
         "purchaseDate": "2019/04/10",
         "warrantyPeriod": "2021/04/10",
-        "disposalDate": "2019/12/1",
         "reason": "印刷がきれい",
         "confort": 5,
         "otherTargets": "特になし",
         "memo": "速い",
-        "isUse": true,
         "photo": "copier"
     },
     {
@@ -55,12 +49,10 @@
         "price": 10000,
         "purchaseDate": "2019/02/10",
         "warrantyPeriod": "2021/02/10",
-        "disposalDate": "2022/12/10",
         "reason": "特になし",
         "confort": 3,
         "otherTargets": "特になし",
         "memo": "電力めっちゃ使う",
-        "isUse": true,
         "photo": "oven"
     }
 ]

--- a/LivingDesign/View/Delete.storyboard
+++ b/LivingDesign/View/Delete.storyboard
@@ -42,7 +42,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="131" height="164"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HLM-zI-5wE">
+                                                <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HLM-zI-5wE" customClass="UILabelWithID" customModule="LivingDesign" customModuleProvider="target">
                                                     <rect key="frame" x="48" y="118" width="35.5" height="20"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="20" id="04p-OF-Ise"/>
@@ -95,6 +95,7 @@
                                         <size key="customSize" width="131" height="164"/>
                                         <connections>
                                             <outlet property="deleteButton" destination="mCD-3g-Bex" id="nX5-eg-Gyj"/>
+                                            <outlet property="titleLabel" destination="HLM-zI-5wE" id="Kz5-bk-nmD"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>

--- a/LivingDesign/View/Delete.storyboard
+++ b/LivingDesign/View/Delete.storyboard
@@ -126,6 +126,9 @@
                                             <constraint firstAttribute="width" constant="40" id="GPs-hz-LvI"/>
                                         </constraints>
                                         <state key="normal" title="完了"/>
+                                        <connections>
+                                            <action selector="touchUpInsideCompleteButton:" destination="DPn-2P-vHz" eventType="touchUpInside" id="teH-lY-AkF"/>
+                                        </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1jt-uS-m96">
                                         <rect key="frame" x="20" y="7.5" width="80" height="30"/>
@@ -133,6 +136,9 @@
                                             <constraint firstAttribute="width" constant="80" id="Hzh-kU-Ddi"/>
                                         </constraints>
                                         <state key="normal" title="取り消し"/>
+                                        <connections>
+                                            <action selector="touchUpInsideCancelButton:" destination="DPn-2P-vHz" eventType="touchUpInside" id="FZb-Kl-vZH"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <color key="backgroundColor" red="0.97256201509999995" green="0.972525537" blue="0.9725503325" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>

--- a/LivingDesign/View/Delete.swift
+++ b/LivingDesign/View/Delete.swift
@@ -77,6 +77,7 @@ class Delete: UIViewController, UICollectionViewDataSource, UICollectionViewDele
         for dci in deleteCandidateItems{
             try! realm.write {
                 realm.delete(realm.objects(Item.self).filter("id == %@",dci.id).first!)
+                realm.objects(AllItem.self).filter("id == %@",dci.id).first?.setDisposalDate(disposalDate: "2019/12/01")
             }
         }
         

--- a/LivingDesign/View/Delete.swift
+++ b/LivingDesign/View/Delete.swift
@@ -15,6 +15,7 @@ class Delete: UIViewController, UICollectionViewDataSource, UICollectionViewDele
     @IBOutlet weak var collectionView: UICollectionView!
     
     private let wireframe: RootViewWireframe = RootViewWireframe()
+    private let resetController: ResetController = ResetController()
     
     let realm = try! Realm()
     
@@ -76,9 +77,10 @@ class Delete: UIViewController, UICollectionViewDataSource, UICollectionViewDele
         for dci in deleteCandidateItems{
             try! realm.write {
                 realm.delete(realm.objects(Item.self).filter("id == %@",dci.id).first!)
-                realm.delete(dci)
             }
         }
+        
+        self.resetController.reset()
         
         let nextStoryBoard = UIStoryboard(name: "Home", bundle: nil)
         let nextViewController = nextStoryBoard.instantiateViewController(withIdentifier: "HomeViewControllerID")
@@ -87,15 +89,7 @@ class Delete: UIViewController, UICollectionViewDataSource, UICollectionViewDele
     
     // 取り消しボタンを押すと、削除リストを削除して、削除画面に戻す（背景色を戻したい）
     @IBAction func touchUpInsideCancelButton(_ sender: Any) {
-        let deleteCandidateItems = realm.objects(DeleteCandidateItem.self)
-
-        if(deleteCandidateItems.first != nil){
-            for dci in deleteCandidateItems{
-                try! realm.write {
-                    realm.delete(dci)
-                }
-            }
-        }
+        self.resetController.reset()
         
         let nextStoryBoard = UIStoryboard(name: "Delete", bundle: nil)
         let nextViewController = nextStoryBoard.instantiateViewController(withIdentifier: "DeleteViewControllerID")

--- a/LivingDesign/View/Delete.swift
+++ b/LivingDesign/View/Delete.swift
@@ -13,6 +13,9 @@ import RealmSwift
 class Delete: UIViewController, UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout{
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var collectionView: UICollectionView!
+    
+    private let wireframe: RootViewWireframe = RootViewWireframe()
+    
     let realm = try! Realm()
     
     override func viewDidLoad() {
@@ -66,4 +69,36 @@ class Delete: UIViewController, UICollectionViewDataSource, UICollectionViewDele
         super.didReceiveMemoryWarning()
     }
     
+    // 完了ボタンを押すと、削除リストを取得して、realmから削除する
+    @IBAction func touchUpInsideCompleteButton(_ sender: Any) {
+        let deleteCandidateItems = realm.objects(DeleteCandidateItem.self)
+
+        for dci in deleteCandidateItems{
+            try! realm.write {
+                realm.delete(realm.objects(Item.self).filter("id == %@",dci.id).first!)
+                realm.delete(dci)
+            }
+        }
+        
+        let nextStoryBoard = UIStoryboard(name: "Home", bundle: nil)
+        let nextViewController = nextStoryBoard.instantiateViewController(withIdentifier: "HomeViewControllerID")
+        self.wireframe.transition(to: nextViewController)
+    }
+    
+    // 取り消しボタンを押すと、削除リストを削除して、削除画面に戻す（背景色を戻したい）
+    @IBAction func touchUpInsideCancelButton(_ sender: Any) {
+        let deleteCandidateItems = realm.objects(DeleteCandidateItem.self)
+
+        if(deleteCandidateItems.first != nil){
+            for dci in deleteCandidateItems{
+                try! realm.write {
+                    realm.delete(dci)
+                }
+            }
+        }
+        
+        let nextStoryBoard = UIStoryboard(name: "Delete", bundle: nil)
+        let nextViewController = nextStoryBoard.instantiateViewController(withIdentifier: "DeleteViewControllerID")
+        self.wireframe.transition(to: nextViewController)
+    }
 }

--- a/LivingDesign/View/Delete.swift
+++ b/LivingDesign/View/Delete.swift
@@ -43,8 +43,9 @@ class Delete: UIViewController, UICollectionViewDataSource, UICollectionViewDele
         // imageViewのサイズ確認用
         // imageView.backgroundColor = .blue
 
-        let label = cell.contentView.viewWithTag(2) as! UILabel
+        let label = cell.contentView.viewWithTag(2) as! UILabelWithID
         label.text = itemInRealm[indexPath.row].name
+        label.id = itemInRealm[indexPath.row].getId()
         // セルのサイズ確認用
         // cell.backgroundColor = .red
         

--- a/LivingDesign/View/DeleteCollectionViewCell.swift
+++ b/LivingDesign/View/DeleteCollectionViewCell.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 import UIKit
- 
+import RealmSwift
+
 class DeleteCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var deleteButton: UIButton!
     @IBOutlet weak var titleLabel: UILabelWithID!
@@ -16,6 +17,15 @@ class DeleteCollectionViewCell: UICollectionViewCell {
     // ボタン内で指を離した際の処理
     @IBAction func touchUpInside(_ sender: Any) {
         deleteButton.backgroundColor = UIColor.init(red: 193/255, green: 24/255, blue: 84/255, alpha: 100/100)
+        let deleteCandidateItem = DeleteCandidateItem()
+        deleteCandidateItem.id = titleLabel.id
+        
+        let realm = try! Realm()
+        try! realm.write {
+            realm.add(deleteCandidateItem)
+        }
+        
+        self.backgroundColor = .red
     }
     
     // ボタン外で指を離した際の処理
@@ -27,6 +37,4 @@ class DeleteCollectionViewCell: UICollectionViewCell {
     @IBAction func touchDown(_ sender: Any) {
         deleteButton.backgroundColor = UIColor.init(red: 255/255, green: 208/255, blue: 226/255, alpha: 100/100)
     }
-    
-
 }

--- a/LivingDesign/View/DeleteCollectionViewCell.swift
+++ b/LivingDesign/View/DeleteCollectionViewCell.swift
@@ -11,6 +11,7 @@ import UIKit
  
 class DeleteCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var deleteButton: UIButton!
+    @IBOutlet weak var titleLabel: UILabelWithID!
     
     // ボタン内で指を離した際の処理
     @IBAction func touchUpInside(_ sender: Any) {

--- a/LivingDesign/View/Footer.swift
+++ b/LivingDesign/View/Footer.swift
@@ -7,11 +7,13 @@
 //
 
 import UIKit
+import RealmSwift
 
 class Footer: UIView {
     @IBOutlet weak var homeButton: UIButton!
     @IBOutlet weak var historyButton: UIButton!
     @IBOutlet weak var settingsButton: UIButton!
+    let realm = try! Realm()
     
     private let wireframe: RootViewWireframe = RootViewWireframe()
     
@@ -34,12 +36,32 @@ class Footer: UIView {
     }
     
     @IBAction func touchUpInsideHistoryButton(_ sender: Any) {
+        let deleteCandidateItems = realm.objects(DeleteCandidateItem.self)
+
+        if(deleteCandidateItems.first != nil){
+            for dci in deleteCandidateItems{
+                try! realm.write {
+                    realm.delete(dci)
+                }
+            }
+        }
+        
         let nextStoryBoard = UIStoryboard(name: "History", bundle: nil)
         let nextViewController = nextStoryBoard.instantiateViewController(withIdentifier: "HistoryViewControllerID")
         self.wireframe.transition(to: nextViewController)
     }
     
     @IBAction func touchUpInsideHomeButton(_ sender: Any) {
+        let deleteCandidateItems = realm.objects(DeleteCandidateItem.self)
+
+        if(deleteCandidateItems.first != nil){
+            for dci in deleteCandidateItems{
+                try! realm.write {
+                    realm.delete(dci)
+                }
+            }
+        }
+        
         let nextStoryBoard = UIStoryboard(name: "Home", bundle: nil)
         let nextViewController = nextStoryBoard.instantiateViewController(withIdentifier: "HomeViewControllerID")
         self.wireframe.transition(to: nextViewController)
@@ -47,6 +69,16 @@ class Footer: UIView {
     
     
     @IBAction func touchUpInsideSettingButton(_ sender: Any) {
+        let deleteCandidateItems = realm.objects(DeleteCandidateItem.self)
+
+        if(deleteCandidateItems.first != nil){
+            for dci in deleteCandidateItems{
+                try! realm.write {
+                    realm.delete(dci)
+                }
+            }
+        }
+        
         let nextStoryBoard = UIStoryboard(name: "Setting", bundle: nil)
         let nextViewController = nextStoryBoard.instantiateViewController(withIdentifier: "SettingViewControllerID")
         self.wireframe.transition(to: nextViewController)

--- a/LivingDesign/View/Footer.swift
+++ b/LivingDesign/View/Footer.swift
@@ -13,7 +13,7 @@ class Footer: UIView {
     @IBOutlet weak var homeButton: UIButton!
     @IBOutlet weak var historyButton: UIButton!
     @IBOutlet weak var settingsButton: UIButton!
-    let realm = try! Realm()
+    private let resetController: ResetController = ResetController()
     
     private let wireframe: RootViewWireframe = RootViewWireframe()
     
@@ -36,15 +36,7 @@ class Footer: UIView {
     }
     
     @IBAction func touchUpInsideHistoryButton(_ sender: Any) {
-        let deleteCandidateItems = realm.objects(DeleteCandidateItem.self)
-
-        if(deleteCandidateItems.first != nil){
-            for dci in deleteCandidateItems{
-                try! realm.write {
-                    realm.delete(dci)
-                }
-            }
-        }
+        self.resetController.reset()
         
         let nextStoryBoard = UIStoryboard(name: "History", bundle: nil)
         let nextViewController = nextStoryBoard.instantiateViewController(withIdentifier: "HistoryViewControllerID")
@@ -52,15 +44,7 @@ class Footer: UIView {
     }
     
     @IBAction func touchUpInsideHomeButton(_ sender: Any) {
-        let deleteCandidateItems = realm.objects(DeleteCandidateItem.self)
-
-        if(deleteCandidateItems.first != nil){
-            for dci in deleteCandidateItems{
-                try! realm.write {
-                    realm.delete(dci)
-                }
-            }
-        }
+        self.resetController.reset()
         
         let nextStoryBoard = UIStoryboard(name: "Home", bundle: nil)
         let nextViewController = nextStoryBoard.instantiateViewController(withIdentifier: "HomeViewControllerID")
@@ -69,15 +53,7 @@ class Footer: UIView {
     
     
     @IBAction func touchUpInsideSettingButton(_ sender: Any) {
-        let deleteCandidateItems = realm.objects(DeleteCandidateItem.self)
-
-        if(deleteCandidateItems.first != nil){
-            for dci in deleteCandidateItems{
-                try! realm.write {
-                    realm.delete(dci)
-                }
-            }
-        }
+        self.resetController.reset()
         
         let nextStoryBoard = UIStoryboard(name: "Setting", bundle: nil)
         let nextViewController = nextStoryBoard.instantiateViewController(withIdentifier: "SettingViewControllerID")

--- a/LivingDesign/View/History.swift
+++ b/LivingDesign/View/History.swift
@@ -20,11 +20,11 @@ class History: UIViewController, UITableViewDataSource, UITableViewDelegate{
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return self.realm.objects(Item.self).count
+        return self.realm.objects(AllItem.self).count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let itemInRealm = self.realm.objects(Item.self)
+        let itemInRealm = self.realm.objects(AllItem.self)
         let cell = tableView.dequeueReusableCell(withIdentifier: "HistoryCell", for: indexPath) as! HistoryTabelViewCell
         
         var genre = itemInRealm[indexPath.row].genre

--- a/LivingDesign/View/ResetController.swift
+++ b/LivingDesign/View/ResetController.swift
@@ -1,0 +1,32 @@
+//
+//  ResetController.swift
+//  LivingDesign
+//
+//  Created by naru on 2019/11/30.
+//  Copyright © 2019 DSN. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+class ResetController{
+    private func resetDeleteCandidate(){
+        let realm = try! Realm()
+        let deleteCandidateItemInRealm = realm.objects(DeleteCandidateItem.self)
+        
+        if(deleteCandidateItemInRealm.first != nil){
+            for dci in deleteCandidateItemInRealm{
+                try! realm.write {
+                    realm.delete(dci)
+                }
+            }
+            print("deleteCandidateItemを削除")
+        } else{
+            print("deleteCandidateItemは空")
+        }
+    }
+    
+    public func reset(){
+        self.resetDeleteCandidate()
+    }
+}

--- a/LivingDesign/View/UILabelWithID.swift
+++ b/LivingDesign/View/UILabelWithID.swift
@@ -1,0 +1,13 @@
+//
+//  UILabelWithID.swift
+//  LivingDesign
+//
+//  Created by naru on 2019/11/25.
+//  Copyright © 2019 DSN. All rights reserved.
+//
+
+import UIKit
+
+class UILabelWithID: UILabel{
+    var id: String = ""
+}


### PR DESCRIPTION
# 削除機能の追加
- 現在使用している製品のみを格納する `Item` の他に、廃棄した製品も含めた `AllItem` を追加
    - Home画面にて、 表示する製品を `isUse` でふるい分けようとしたが、collectionViewを使いこなせず、断念し、`Item`と`AllItem`を導入することにした。（IndexPathにisUseがfalseなもののみを格納できれば実現可能だが、その方法がわからなかった）
    - `Item` はHome画面、Delete画面にて読み込む
    - `AllItem` はHistory画面にて読み込む
- ×ボタンで削除リスト `DeleteCandidateItem` に追加 & 背景赤色に変更
- 完了ボタン押下で、削除リストに格納された製品をItemから削除 & AllItemのisUseを `setDisposalDate()` により更新 & 削除リストのリセット & Home画面に遷移
- 取り消しボタン押下で、削除リストをリセットし、Delete画面に遷移
- フッターの各ボタン押下で、削除リストをリセットし、各画面に遷移
- アプリ起動時に、削除リストをリセット